### PR TITLE
default namespace added

### DIFF
--- a/elasticsearch-chart/templates/es-rbac.yaml
+++ b/elasticsearch-chart/templates/es-rbac.yaml
@@ -17,6 +17,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: {{.Values.name}}
+  namespace: {{.Values.namespace}}
   labels:
     app: {{.Values.name}}
     kubernetes.io/cluster-service: "true"
@@ -24,6 +25,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{.Values.name}}
+  namespace: {{.Values.namespace}}
   apiGroup: ""
 roleRef:
   kind: ClusterRole

--- a/elasticsearch-chart/values.yaml
+++ b/elasticsearch-chart/values.yaml
@@ -5,6 +5,7 @@
 
 image: quay.io/samsung_cnct/elasticsearch-container
 name: elasticsearch
+namespace: default
 
 #Services
 port: 9200


### PR DESCRIPTION
we removed kube-logging as the go-to logging namespace, but namespace is a required value for clusterRoleBinding , so I added in the default namespace in values.yaml