### PR TITLE
Fixed initContainer for k8s v1.8.1  (backwards compatible to 1.6)

### DIFF
--- a/elasticsearch-chart/templates/es-data-statefulset.yaml
+++ b/elasticsearch-chart/templates/es-data-statefulset.yaml
@@ -11,21 +11,21 @@ spec:
       labels:
         app: {{.Values.name}}
         name: {{.Values.data_name}}
-      annotations:
-        pod.alpha.kubernetes.io/init-containers: '[
-            {
-                "name": "max-map-count-set",
-                "image": "quay.io/samsung_cnct/set_max_map_count:1.1",
-                "volumeMounts": [
-                    {
-                        "name": "hostproc",
-                        "mountPath": "/hostproc"
-                    }
-                ]
-            }]'
     spec:
       serviceAccount: {{.Values.name}}
       serviceAccountName: {{.Values.name}}
+      initContainers:
+      - name: max-map-count-set
+        image: quay.io/samsung_cnct/set_max_map_count:1.1
+        volumeMounts: [
+          { "name": "hostproc", 
+            "mountPath": "/hostproc"
+          }]
+      - name: sysctl
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["sysctl", "-w", "vm.max_map_count=262144"]
+        securityContext: {"privileged": true}
       containers:
       - name: {{.Values.name}}
         image: {{.Values.image}}

--- a/elasticsearch-chart/templates/es-master-statefulset.yaml
+++ b/elasticsearch-chart/templates/es-master-statefulset.yaml
@@ -11,21 +11,21 @@ spec:
       labels:
         app: {{.Values.name}}
         name: {{.Values.master_name}}
-      annotations:
-        pod.alpha.kubernetes.io/init-containers: '[
-            {
-                "name": "max-map-count-set",
-                "image": "quay.io/samsung_cnct/set_max_map_count:1.1",
-                "volumeMounts": [
-                    {
-                        "name": "hostproc",
-                        "mountPath": "/hostproc"
-                    }
-                ]
-            }]'
     spec:
       serviceAccount: {{.Values.name}}
       serviceAccountName: {{.Values.name}}
+      initContainers:
+      - name: max-map-count-set
+        image: quay.io/samsung_cnct/set_max_map_count:1.1
+        volumeMounts: [
+          { "name": "hostproc", 
+            "mountPath": "/hostproc"
+          }]
+      - name: sysctl
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["sysctl", "-w", "vm.max_map_count=262144"]
+        securityContext: {"privileged": true}
       containers:
       - name: {{.Values.name}}
         image: {{.Values.image}}


### PR DESCRIPTION
Used correct initContainer format for 1.8, and increased vm.max_map_count to fix bootstrap error (to recommended size)
