### PR TITLE
Making tag "latest" so that during non-releases, latest (devel) stuff…

### DIFF
--- a/elasticsearch-chart/values.yaml
+++ b/elasticsearch-chart/values.yaml
@@ -9,7 +9,7 @@ name: elasticsearch
 
 #Testing (just needs curl)
 test_image: quay.io/samsung_cnct/e2etester
-test_tag: 0.2
+test_tag: latest
 
 #Services
 port: 9200


### PR DESCRIPTION
… gets installed by default. We will look to chart-logging values file to be prescritpive about the release versions of tags to use.