### PR TITLE
Reverted previous change. It was in the wrong place. Making tag "latest" ...

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ build_chart:
   only:
     - tags
     - branches
-  artifacts: 
+  artifacts:
     paths:
       - ${CHART_NAME}
   script:
@@ -50,7 +50,7 @@ helm_test:
 clean_test:
   image: $KUBECTL_IMAGE
   stage: clean
-  allow_failure: true
+  allow_failure: false
   only:
     - tags
     - branches

--- a/build/clean-install.sh
+++ b/build/clean-install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# This script un-installs the helm chart and 
+# This script un-installs the helm chart and
 # manually removes PVCs
 
 set -o errexit
@@ -10,21 +10,44 @@ set -o pipefail
 CHART_NAME=${CHART_NAME:?CHART_NAME must be set}
 NAMESPACE=${NAMESPACE:?NAMESPACE must be set}
 RELEASE=${RELEASE:?RELEASE must be set}
+ATTEMPT=0
+TRY_THRESH=3
+
+is_success()
+{
+  local count
+
+  count=$(helm ls -a "$RELEASE" | wc -l)
+
+  [[ $count -gt 0 ]] && return 1
+  return 0
+}
 
 if [[ ! -d ${CHART_NAME} ]]; then
   echo >&2 "Directory for chart '$CHART_NAME' does not exist."
-  exit 1
+  exit 8
 fi
 
 # cleanup
 echo Cleaning up
-helm delete --purge ${RELEASE} &> /dev/null &
-
 echo Waiting for un-install
-sleep 600
+
+while ! is_success; do
+  [[ $ATTEMPT -ge $TRY_THRESH ]] && \
+    {
+      echo >&2 "helm was not able to delete/purge existing release: $RELEASE after $ATTEMPT tries."
+      exit 10
+    }
+
+  helm delete --purge "${RELEASE}" &> /dev/null &
+  wait
+
+  echo >&2 "helm was unable to delete/purge $RELEASE on attempt $ATTEMPT"
+  ((ATTEMPT++))
+done
 
 # Note: This assumes the default storage class has been
 # created with a reclaimPolicy of Delete. Otherwise the
 # PVs will need to be manually deleted.
 echo Deleting associated PVCs
-kubectl delete pvc -l app=elasticsearch -n  ${NAMESPACE}
+kubectl delete pvc -l app=elasticsearch -n "${NAMESPACE}"

--- a/elasticsearch-chart/values.yaml
+++ b/elasticsearch-chart/values.yaml
@@ -4,12 +4,12 @@
 # name: value
 
 image: quay.io/samsung_cnct/elasticsearch-container
-tag: v0.2.0
+tag: latest
 name: elasticsearch
 
 #Testing (just needs curl)
 test_image: quay.io/samsung_cnct/e2etester
-test_tag: latest
+test_tag: 0.2
 
 #Services
 port: 9200

--- a/elasticsearch-chart/values.yaml
+++ b/elasticsearch-chart/values.yaml
@@ -9,7 +9,7 @@ name: elasticsearch
 
 #Testing (just needs curl)
 test_image: quay.io/samsung_cnct/e2etester
-test_tag: 0.2
+test_tag: latest
 
 #Services
 port: 9200


### PR DESCRIPTION
...so that during non-prod releases, latest (devel) stuff gets installed by default. We will look to chart-logging values file to be prescriptive about the release versions of tags to use.