### PR TITLE
add optional ingress stanza and sample values

### DIFF
--- a/charts/elasticsearch-chart/templates/services.yaml
+++ b/charts/elasticsearch-chart/templates/services.yaml
@@ -43,7 +43,7 @@ spec:
     app: {{.Values.name}}
 
 ---
-{{- if .Values.ingress.host }}
+{{- if .Values.ingress }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/charts/elasticsearch-chart/templates/services.yaml
+++ b/charts/elasticsearch-chart/templates/services.yaml
@@ -41,3 +41,21 @@ spec:
   clusterIP: None
   selector:
     app: {{.Values.name}}
+
+---
+{{- if .Values.ingress.host }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{.Values.name}}
+spec:
+  rules:
+  - host: {{ .Values.ingress.host }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{.Values.data_name}}
+          servicePort: {{.Values.port}}
+
+{{- end }}

--- a/charts/elasticsearch-chart/values.yaml
+++ b/charts/elasticsearch-chart/values.yaml
@@ -79,3 +79,8 @@ data_scheduling:
       # - key: iamalabelkey
       #   operator: In
       #   values: ["value1", "value2"]
+
+#  if you want to be able to write data to this cluster from 
+#  outside the cluster, set the ingress.host value
+#ingress:
+#  host: elasticsearch.ingest.company.org


### PR DESCRIPTION
adds the ability to specify an externally accessible write point
for getting data into the elasticsearch cluster created by this
chart.

there is no security included with this so ensure security is
complete in the supporting systems.