### PR TITLE
set new value for "master_create_storage_class"

### DIFF
--- a/charts/elasticsearch-chart/values.yaml
+++ b/charts/elasticsearch-chart/values.yaml
@@ -28,7 +28,7 @@ elastic_password_value: "changeme"
 #Master StatefulSet
 #
 # Need a storage class for CI testing
-master_create_storage_class: false
+master_create_storage_class: true
 #
 master_name: elasticsearch-master
 # master_replicas: if changing this value, please also update the

--- a/charts/elasticsearch-chart/values.yaml
+++ b/charts/elasticsearch-chart/values.yaml
@@ -3,7 +3,7 @@
 # Declare name/value pairs to be passed into your templates.
 # name: value
 
-image: k8s.gcr.io/elasticsearch:v6.2.4
+image: docker.elastic.co/elasticsearch/elasticsearch-platinum:6.2.4
 name: elasticsearch
 
 #Testing (just needs curl)
@@ -17,6 +17,13 @@ cluster_name: elasticsearch-cluster
 cluster_port: 9300
 cluster_port_name: cluster-comms
 service_name: elasticsearch-discovery
+
+#enviroment
+xpack_security_enabled: XPACK.SECURITY.ENABLED
+xpack_security_value: "true"
+
+elastic_password: ELASTIC_PASSWORD
+elastic_password_value: "changeme"
 
 #Master StatefulSet
 #


### PR DESCRIPTION
in my case, at the first time to install this chart, you should be set "master_create_storage_class" value to "true". only "master_create_storage_class" not "data_create_storage_class".

actually, i don't know why do i have to like this. so, please test and review at cleaned cluster environment.